### PR TITLE
Feature: 支持模糊匹配

### DIFF
--- a/fontra/__init__.py
+++ b/fontra/__init__.py
@@ -210,10 +210,16 @@ def get_font(name: FontFamilyName, style: str, localized: bool = True) -> FontRe
     name = get_unlocalized_name(name) if localized else name
     if name not in _indexed_fontrefs:
         match = get_close_matches(name, _indexed_fontrefs.keys())
-        raise KeyError(f"Font {name!r} not found. Did you mean {match[0]!r} ?")
+        raise KeyError(
+            f"Font {name!r} not found."
+            + (f" Did you mean {match[0]!r} ?" if match else "")
+        )
     if style not in (_fonts := _indexed_fontrefs[name]):
         match = get_close_matches(style, _fonts.keys())
-        raise KeyError(f"Font style {style!r} of font {name!r} not found. Did you mean '{match[0]!r}' ?")
+        raise KeyError(
+            f"Font style {style!r} of font {name!r} not found."
+            + (f" Did you mean {match[0]!r} ?" if match else "")
+        )
     return _fonts[style]
 
 
@@ -229,7 +235,10 @@ def get_font_styles(name: FontFamilyName, localized: bool = True) -> list[StyleN
     name = get_unlocalized_name(name) if localized else name
     if name not in _indexed_fontrefs:
         match = get_close_matches(name, _indexed_fontrefs.keys())
-        raise KeyError(f"Font {name!r} not found. Did you mean {match[0]!r} ?")
+        raise KeyError(
+            f"Font {name!r} not found."
+            + (f" Did you mean {match[0]!r} ?" if match else "")
+        )
     return [st for st in _indexed_fontrefs[name]]
 
 

--- a/fontra/__init__.py
+++ b/fontra/__init__.py
@@ -11,6 +11,7 @@ from typing import cast
 
 import freetype
 import freetype.ft_errors
+from difflib import get_close_matches
 from typing_extensions import NamedTuple, TypeAlias
 
 FontFamilyName: TypeAlias = str
@@ -208,9 +209,11 @@ def get_font(name: FontFamilyName, style: str, localized: bool = True) -> FontRe
     """
     name = get_unlocalized_name(name) if localized else name
     if name not in _indexed_fontrefs:
-        raise KeyError(f"Font {name!r} not found")
+        match = get_close_matches(name, _indexed_fontrefs.keys())
+        raise KeyError(f"Font {name!r} not found. Did you mean {match[0]!r} ?")
     if style not in (_fonts := _indexed_fontrefs[name]):
-        raise KeyError(f"Font style {style!r} of font {name!r} not found")
+        match = get_close_matches(style, _fonts.keys())
+        raise KeyError(f"Font style {style!r} of font {name!r} not found. Did you mean '{match[0]!r}' ?")
     return _fonts[style]
 
 
@@ -225,7 +228,8 @@ def get_font_styles(name: FontFamilyName, localized: bool = True) -> list[StyleN
     """
     name = get_unlocalized_name(name) if localized else name
     if name not in _indexed_fontrefs:
-        raise KeyError(f"Font {name!r} not found")
+        match = get_close_matches(name, _indexed_fontrefs.keys())
+        raise KeyError(f"Font {name!r} not found. Did you mean {match[0]!r} ?")
     return [st for st in _indexed_fontrefs[name]]
 
 

--- a/fontra/__main__.py
+++ b/fontra/__main__.py
@@ -113,11 +113,12 @@ def path() -> None:
 @app.command(help="Show the font information.")
 def show(
     name: Annotated[List[FontFamilyName], Argument(help="Font family name.")], 
-    localized: Annotated[bool, Option(help="Whether to lookup localized index.")] = True
+    localized: Annotated[bool, Option(help="Whether to lookup localized index.")] = True,
+    fuzzy: Annotated[bool, Option("--fuzzy/--no-fuzzy", "-f/-F", help="Whether to fuzzy match.")] = False
 ) -> None:
     try:
         font_name = " ".join(name)
-        styles = get_font_styles(font_name, localized)
+        styles = get_font_styles(font_name, localized, fuzzy)
         console.print(f"The font family '{font_name}' contains {len(styles)} styles:")
         for style in styles:
             console.print(f"- {style}")


### PR DESCRIPTION
```python
>>> import fontra
>>> fontra.get_font_styles("Cascadia")
KeyError: "Font 'Cascadia' not found. Did you mean 'Cascadia Mono' ?"
>>> fontra.get_font("Cascadia", "Roman")
KeyError: "Font 'Cascadia' not found. Did you mean 'Cascadia Mono' ?"
>>> fontra.get_font("Cascadia Mono", "Roma")
KeyError: "Font style 'Roma' of font 'Cascadia Mono' not found. Did you mean 'Roman' ?"

>>> fontra.get_font_styles("Cascadia", fuzzy=True)
['Roman']
>>> fontra.get_font("Cascadia", "Roman", fuzzy=True)
FontRef(path=WindowsPath('C:/windows/fonts/CascadiaMono.ttf'), bank=0)
>>> fontra.get_font("Cascadia Mono", "Roma", fuzzy=True)
FontRef(path=WindowsPath('C:/windows/fonts/CascadiaMono.ttf'), bank=0)
```